### PR TITLE
Adding Facebook Share Dialog instead of the Feed Dialog.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Argument | Description | Used By
 {desc} | A longer description of the content you are sharing | Most
 {app_id} | The App ID | Facebook
 {redirect_url} | The url a sharer will be redirected to after a successful share | Facebook
-{via} | optional Twitter username of content author (don't include "@") | Twitter 
+{via} | optional Twitter username of content author (don't include "@") | Twitter
 {hashtags} | optional Hashtags appended onto the tweet (comma separated. don't include "#") | Twitter
 {provider} | Company who is sharing the url | Delicious
 {is_video} | If the content is a video or not | Pinterest
@@ -34,8 +34,7 @@ Argument | Description | Used By
 
 ### Facebook
 
-Facebook has two methods of sharing. The simpler option is to use the link "Sharer", but their newer “Feed Dialog” option offers more customization, but on the other hand, requires a Facebook App ID.
-[Facebook Feed Dialog vs. Share Link Dialog](http://www.local-pc-guy.com/web-dev/facebook-feed-dialog-vs-share-link-dialog) is a great article explaining the differences between the two methods.
+Facebook has two methods of sharing. The "Sharer" link is simple but the preferred Facebook way is using the [Share Dialog](https://developers.facebook.com/docs/sharing/reference/share-dialog). This method does require an app id but offers more flexibility.
 
 #### Sharer:
 
@@ -43,10 +42,10 @@ Facebook has two methods of sharing. The simpler option is to use the link "Shar
 http://www.facebook.com/sharer.php?u={url}
 ```
 
-#### Feed Dialog:
+#### Share Dialog:
 
 ```
-https://www.facebook.com/dialog/feed?app_id={app_id}&link={url}&picture={img}&name={title}&description={desc}&redirect_uri={redirect_url}
+https://www.facebook.com/dialog/share?app_id={app_id}&display=page&href={url}&redirect_uri={redirect_url}
 ```
 
 ### Twitter

--- a/generator.js
+++ b/generator.js
@@ -1,7 +1,7 @@
 (function (window, undefined) {
 
 	window.SocialShare = { };
-	
+
 	SocialShare.Networks = [
 		{
 			name: 'Facebook',
@@ -9,9 +9,9 @@
 			url: 'http://www.facebook.com/sharer.php?s=100&p[url]={url}&p[images][0]={img}&p[title]={title}&p[summary]={desc}'
 		},
 		{
-			name: 'Facebook (feed dialog)',
+			name: 'Facebook (share dialog)',
 			class: 'facebook',
-			url: 'https://www.facebook.com/dialog/feed?app_id={app_id}&link={url}&picture={img}&name={title}&description={desc}&redirect_uri={redirect_url}'
+			url: 'https://www.facebook.com/dialog/share?app_id={app_id}&display=page&href={url}&redirect_uri={redirect_url}'
 		},
 		{
 			name: 'Twitter',
@@ -62,9 +62,9 @@
 			name: 'Delicious',
 			class: 'delicious',
 			url: 'https://delicious.com/save?v=5&provider={provider}&noui&jump=close&url={url}&title={title}',
-		}	
+		}
 	];
-	
+
 	SocialShare.generateSocialUrls = function(opt) {
 		if (typeof opt !== 'object') { return false; }
 		var links = [], network;
@@ -77,8 +77,8 @@
 			});
 		}
 		return links;
-	};	
-	
+	};
+
 	SocialShare.generateUrl = function(url, opt) {
 		var prop, arg, arg_ne;
 		for (prop in opt) {
@@ -93,46 +93,46 @@
 		}
 		return this.cleanUrl(url);
 	};
-	
+
 	SocialShare.cleanUrl = function(fullUrl) {
 		//firstly, remove any expressions we may have left in the url
 		fullUrl = fullUrl.replace(/\{([^{}]*)}/g, '');
-		
+
 		//then remove any empty parameters left in the url
 		var params = fullUrl.match(/[^\=\&\?]+=[^\=\&\?]+/g),
 			url = fullUrl.split("?")[0];
 		if (params && params.length > 0) {
 			url += "?" + params.join("&");
 		}
-		
-		return url;		
+
+		return url;
 	};
-	
+
 	SocialShare.doPopup = function(e) {
 		e = (e ? e : window.event);
 		var t = (e.target ? e.target : e.srcElement),
 			width = t.data-width || 800,
 			height = t.data-height || 500;
-		
- 
+
+
 		// popup position
 		var
 			px = Math.floor(((screen.availWidth || 1024) - width) / 2),
 			py = Math.floor(((screen.availHeight || 700) - height) / 2);
- 
+
 		// open popup
-		var popup = window.open(t.href, "social", 
+		var popup = window.open(t.href, "social",
 			"width="+width+",height="+height+
 			",left="+px+",top="+py+
 			",location=0,menubar=0,toolbar=0,status=0,scrollbars=1,resizable=1");
-			
+
 		if (popup) {
 			popup.focus();
 			if (e.preventDefault) e.preventDefault();
 			e.returnValue = false;
 		}
- 
+
 		return !!popup;
 	};
- 
+
 })(window);


### PR DESCRIPTION
The Feed Dialog is being [deprecated](https://developers.facebook.com/docs/sharing/reference/feed-dialog/v2.0) right now and Facebook is directing people to use the [Share Dialog](https://developers.facebook.com/docs/sharing/reference/share-dialog) instead.
