### PR TITLE
Correct Twitter share URL to /intent/tweet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ https://www.facebook.com/dialog/share?app_id={app_id}&display=page&href={url}&re
 ### Twitter
 
 ```
-https://twitter.com/share?url={url}&text={title}&via={via}&hashtags={hashtags}
+https://twitter.com/intent/tweet?url={url}&text={title}&via={via}&hashtags={hashtags}
 ```
 
 ### Google+

--- a/generator.js
+++ b/generator.js
@@ -16,7 +16,7 @@
 		{
 			name: 'Twitter',
 			class: 'twitter',
-			url: 'https://twitter.com/share?url={url}&text={title}&via={via}&hashtags={hashtags}'
+			url: 'https://twitter.com/intent/tweet?url={url}&text={title}&via={via}&hashtags={hashtags}'
 		},
 		{
 			name: 'Google+',


### PR DESCRIPTION
The reasoning:

1. The `/share` URL redirects there anyway.
2. It plays much nicer with (at the very least) the iOS Twitter app, whereas /share does not. As one example, if you have `target="_blank"` set on the link (rather than using JS popups), Safari on iOS knows to hand control of `/intent/tweet` to the app, whereas when a window is opened to `/share` it has to follow the redirect to `/intent/tweet` first, and because of the redirect it leaves a blank tab open in the browser when one returns to it.