### PR TITLE
Use HTTPS links where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Facebook has two methods of sharing. The "Sharer" link is simple but the preferr
 #### Sharer:
 
 ```
-http://www.facebook.com/sharer.php?u={url}
+https://www.facebook.com/sharer.php?u={url}
 ```
 
 #### Share Dialog:
@@ -66,16 +66,16 @@ https://plus.google.com/share?url={url}
 https://pinterest.com/pin/create/bookmarklet/?media={img}&url={url}&is_video={is_video}&description={title}
 ```
 
-### Linked In
+### LinkedIn
 
 ```
-http://www.linkedin.com/shareArticle?url={url}&title={title}
+https://www.linkedin.com/shareArticle?url={url}&title={title}
 ```
 
 ### Buffer
 
 ```
-http://bufferapp.com/add?text={title}&url={url}
+https://buffer.com/add?text={title}&url={url}
 ```
 
 ### Digg
@@ -93,7 +93,7 @@ https://www.tumblr.com/widgets/share/tool?canonicalUrl={url}&title={title}&capti
 ### Reddit
 
 ```
-http://reddit.com/submit?url={url}&title={title}
+https://reddit.com/submit?url={url}&title={title}
 ```
 
 ### StumbleUpon

--- a/generator.js
+++ b/generator.js
@@ -6,7 +6,7 @@
 		{
 			name: 'Facebook',
 			class: 'facebook',
-			url: 'http://www.facebook.com/sharer.php?s=100&p[url]={url}&p[images][0]={img}&p[title]={title}&p[summary]={desc}'
+			url: 'https://www.facebook.com/sharer.php?s=100&p[url]={url}&p[images][0]={img}&p[title]={title}&p[summary]={desc}'
 		},
 		{
 			name: 'Facebook (share dialog)',
@@ -31,12 +31,12 @@
 		{
 			name: 'Linked In',
 			class: 'linkedin',
-			url: 'http://www.linkedin.com/shareArticle?url={url}&title={title}',
+			url: 'https://www.linkedin.com/shareArticle?url={url}&title={title}',
 		},
 		{
 			name: 'Buffer',
 			class: 'buffer',
-			url: 'http://bufferapp.com/add?text={title}&url={url}',
+			url: 'https://buffer.com/add?text={title}&url={url}',
 		},
 		{
 			name: 'Digg',
@@ -46,12 +46,12 @@
 		{
 			name: 'Tumblr',
 			class: 'tumblr',
-			url: 'http://www.tumblr.com/share/link?url={url}&name={title}&description={desc}',
+			url: 'https://www.tumblr.com/widgets/share/tool?canonicalUrl={url}&title={title}&caption={desc}',
 		},
 		{
 			name: 'Reddit',
 			class: 'reddit',
-			url: 'http://reddit.com/submit?url={url}&title={title}',
+			url: 'https://reddit.com/submit?url={url}&title={title}',
 		},
 		{
 			name: 'StumbleUpon',


### PR DESCRIPTION
LinkedIn, Reddit, Buffer, and Facebook `sharer.php` all support HTTPS, so these links should be used instead.

Additional fixes: use canonical spelling of LinkedIn (it's a single word in their branding), use new Buffer URL (it's just `buffer.com`, not `bufferapp.com`, the latter redirects to the former) and correct a divergence between generator.js and the README.