### PR TITLE
updated xing share api link

### DIFF
--- a/code/javascript/javascript/social-share-media.js
+++ b/code/javascript/javascript/social-share-media.js
@@ -188,7 +188,7 @@ function GetSocialMediaSiteLinks_WithShareLinks(args) {
 		'twitter':'https://twitter.com/intent/tweet?url=' + url + '&text=' + text + '&via=' + via + '&hashtags=' + hash_tags,
 		'vk':'http://vk.com/share.php?url=' + url + '&title=' + title + '&comment=' + desc,
 		'weibo':'http://service.weibo.com/share/share.php?url=' + url + '&appkey=&title=' + title + '&pic=&ralateUid=',
-		'xing':'https://www.xing.com/app/user?op=share&url=' + url,
+		'xing':'https://www.xing.com/spi/shares/new?url=' + url,
 		'yahoo':'http://compose.mail.yahoo.com/?to=' + email_address + '&subject=' + title + '&body=' + text,
 	};
 }


### PR DESCRIPTION
On https://dev.xing.com/plugins/share_button/docs#custom-design you can see the new api url for sharing a xing post.