### PR TITLE
js: Rename "pinterest.com" to "pinterest" to fix GetSocialMediaSites_NiceNames

### DIFF
--- a/code/javascript/javascript/social-share-media.js
+++ b/code/javascript/javascript/social-share-media.js
@@ -27,7 +27,7 @@ function GetSocialMediaSites_NiceNames() {
 		'gmail':'GMail',
 		'hacker.news':'HackerNews',
 		'ok.ru':'OK.ru',
-		'pinterest.com':'Pinterest',
+		'pinterest':'Pinterest',
 		'qzone':'QZone',
 		'reddit':'Reddit',
 		'renren':'RenRen',


### PR DESCRIPTION
"pinterest.com" is not the name of the provider. It should be "pinterest" instead, correct?